### PR TITLE
fix keys in base.yaml to match rosdep

### DIFF
--- a/yaml/base.yaml
+++ b/yaml/base.yaml
@@ -38,7 +38,7 @@ boost:
     library_dirs:
     - Boost_LIBRARY_DIRS
     name: Boost
-boost-python:
+libboost-python:
   cmake:
     include_dirs:
       - BoostPython_INCLUDE_DIRS
@@ -176,7 +176,7 @@ libcairo2-dev:
     - CAIRO_LIBRARIES
     library_dirs: []
     name: Cairo
-libgeographic-dev:
+geographiclib:
   cmake:
     components: []
     include_dirs:
@@ -662,7 +662,7 @@ poco:
     name: Poco
   ubuntu:
   - libpoco-dev
-pugixml:
+pugixml-dev:
   cmake:
     components: []
     include_dirs:


### PR DESCRIPTION
## Description
Some keys in base.yaml do not match with rosdep keys and causing package.xml to be incompatible with rosdep install command.
I have fixed some of the keys so that autodep and rosdep both refer to same key.

Changed keys:
libgeographic-dev -> geographiclib
boost-python -> libboost-python
pugixml -> pugixml-dev

## Notes
libboost-python is not merged at current moment. Please merge this PR after https://github.com/ros/rosdistro/pull/21570 is merged to rosdistro repository. 

Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>