### PR TITLE
Removing coverage key in favor of lcov and gcovr.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,8 @@
   <url type="repository">https://gitlab.mrt.uni-karlsruhe.de/MRT/mrt_cmake_modules.git</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>coverage</buildtool_depend>
+  <buildtool_depend>gcovr</buildtool_depend>
+  <buildtool_depend>lcov</buildtool_depend>
 
   <export>
     <architecture_independent/>

--- a/yaml/base.yaml
+++ b/yaml/base.yaml
@@ -18,12 +18,6 @@ armadillo:
     name: Armadillo
   ubuntu:
   - libarmadillo-dev
-coverage:
-  ubuntu:
-    xenial:
-    - lcov
-    bionic:
-    - gcovr
 boost:
   cmake:
     components:


### PR DESCRIPTION
This resolves #2. As cmake/Modules/MRTCoverage.cmake appears to want both installed (or at least one), both are available on Xenial and Bionic, and MRTCoverage.cmake chooses based on it's own rules, why not just install both?