### PR TITLE
Fix build for non-x86 architectures

### DIFF
--- a/cmake/Modules/UseMrtStdCompilerFlags.cmake
+++ b/cmake/Modules/UseMrtStdCompilerFlags.cmake
@@ -41,14 +41,29 @@ endif()
 # Select arch flag
 if(MRT_ARCH)
   if(NOT MRT_ARCH STREQUAL "None" AND NOT MRT_ARCH STREQUAL "none")
-    set(_arch "-march=${MRT_ARCH}")
+    set(_arch "${MRT_ARCH}")
   endif()
 else()
-  # sandybridge is the lowest common cpu arch for us
-  set(_arch "-march=sandybridge")
+  # On X86, sandybridge is the lowest common cpu arch for us
+  set(_x86_arch_list "i386" "amd64" "AMD64" "x86_64" "i686" "x86" "x64" "EM64T")
+
+  list(FIND _x86_arch_list ${CMAKE_SYSTEM_PROCESSOR} _index)
+
+  if(${_index} GREATER -1)
+    message(STATUS "MRT_ARCH not set and X86 target detected (${CMAKE_SYSTEM_PROCESSOR})")
+    set(_arch "sandybridge")
+  endif()
+
+  unset(_x86_arch_list)
+  unset(_index)
 endif()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_arch}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_arch}")
+
+if(_arch)
+  message(STATUS "Setting -march to " ${_arch})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=${_arch}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${_arch}")
+  unset(_arch)
+endif()
 
 # add OpenMP if present
 # it would be great to have this in package.xmls instead, but catkin cannot handle setting the required cmake flags for dependencies


### PR DESCRIPTION
When MRT_ARCH is not explicitly set, UseMrtStdCompilerFlags.cmake
currently forces the target architecture to be tuned to the Sandy Bridge
(x86) architecture.

This patch constraints this behaviour to x86-based targets. This allow
projects based on MRT Cmake Modules to be rebuild transparently in other
architectures without any extra build settings.

Note that this change works with both cross-compilation and native
non-x86 builds.

See #7.

Change-Id: Ibc1ed1eaf1c014df4c44d774ea8fd3760a1679e7
Signed-off-by: Filipe Rinaldi <filipe.rinaldi@arm.com>