### PR TITLE
Fix linking against python3 version of boost python on cmake>=3.11.

### DIFF
--- a/cmake/Modules/FindBoostPython.cmake
+++ b/cmake/Modules/FindBoostPython.cmake
@@ -16,7 +16,7 @@ if(CMAKE_VERSION VERSION_GREATER 3.11)
     find_package(Boost COMPONENTS python${_python_version} numpy${_python_version})
 endif()
 
-if(NOT (Boost_python${_python_version}_FOUND OR Boost_python_FOUND))
+if(NOT (Boost_PYTHON${_python_version}_FOUND OR Boost_python_FOUND))
     find_package(Boost REQUIRED COMPONENTS python)
     find_package(Boost QUIET COMPONENTS numpy) # numpy is not available on some boost versions
     set(Python_ADDITIONAL_VERSIONS ${_python_version})
@@ -30,7 +30,7 @@ elseif(_python_version VERSION_LESS 3)
 else()
     find_package(Python3 REQUIRED COMPONENTS Development)
     set(BoostPython_INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${Python3_INCLUDE_DIRS})
-    set(BoostPython_LIBRARIES ${Boost_PYTHON3.6_LIBRARY} ${Boost_NUMPY3.6_LIBRARY} ${Python3_LIBRARIES})
+    set(BoostPython_LIBRARIES ${Boost_PYTHON${_python_version}_LIBRARY} ${Boost_NUMPY${_python_version}_LIBRARY} ${Python3_LIBRARIES})
 endif()
 
 find_package_handle_standard_args(BoostPython DEFAULT_MSG BoostPython_LIBRARIES BoostPython_INCLUDE_DIRS)


### PR DESCRIPTION
This is a fix for https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/93.

With python3, it always linked the python2 version of boost-python, although `PYTHON_VERSION` and `PYTHON_INTERPRETER` were defined correctly. I tracked this down to ` ${Boost_PYTHON_LIBRARIES}` evaluating to `/usr/lib/x86_64-linux-gnu/libboost_python.so`, which is a symlink to the python2 version. With this PR, the issue should be fixed for CMake >= 3.11 (tested with CMake 3.14), because a typo prevented using the correct if/else branch. For older CMake versions, the issue is still there because I couldn't find a way to get `find_package(Boost REQUIRED COMPONENTS python)` to find the python3 version of the library and not the symlink.

With this PR, it now also works with python 3.7 by not hardcoding python 3.6.