### PR TITLE
Replace deprecated platform.distro call with distro module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mrt_cmake_modules)
 
 find_package(catkin REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-argparse</exec_depend>
   <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</buildtool_export_depend>
   <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</buildtool_export_depend>
+  <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 2">python-distro</buildtool_export_depend>
+  <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-distro</buildtool_export_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/scripts/generate_cmake_dependency_file.py
+++ b/scripts/generate_cmake_dependency_file.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import os
 import sys
 import subprocess
-import platform
+import distro
 import yaml
 from catkin_pkg.packages import find_packages
 from string import Template
@@ -142,18 +142,18 @@ def readPackageCMakeData(rosDebYamlFileName):
     # dictionary for storing cmake dependencies
     # e.g. { "<package name 1>" -> PackageCMakeData, "<package name 2>" -> PackageCMakeData ... }
     data = {}
-    distro = platform.dist()[2]
+    linux_distribution = distro.linux_distribution()[2]
     if 'ROS_OS_OVERRIDE' in os.environ:
         ros_os_override = os.environ['ROS_OS_OVERRIDE'].split(':')
         if len(ros_os_override) == 2:
-            distro = ros_os_override[1]
+            linux_distribution = ros_os_override[1]
 
     for packageName, packageCMakeData in rosDebYamlData.items():
         # find out which distribution
         if "name" in packageCMakeData:
             data[packageName] = PackageCMakeData(packageCMakeData)
-        elif distro in packageCMakeData:
-            data[packageName] = PackageCMakeData(packageCMakeData[distro])
+        elif linux_distribution in packageCMakeData:
+            data[packageName] = PackageCMakeData(packageCMakeData[linux_distribution])
         elif not packageCMakeData:
             data[packageName] = PackageCMakeData()  # placeholder
     return data


### PR DESCRIPTION
Proposed fix for #12. Also added python-distro or python3-distro as build dependency.