### PR TITLE
Run GatherDeps with correct python version if PYTHON_VERSION is set.

### DIFF
--- a/cmake/Modules/GatherDeps.cmake
+++ b/cmake/Modules/GatherDeps.cmake
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED)
 set(_gather_cmd
     sh
     ${CATKIN_ENV}
-    python
+    python${PYTHON_VERSION}
     ${MRT_CMAKE_MODULES_ROOT_PATH}/scripts/generate_cmake_dependency_file.py
     "${CMAKE_CURRENT_SOURCE_DIR}/package.xml"
     "${MRT_CMAKE_MODULES_ROOT_PATH}/yaml/cmake.yaml"


### PR DESCRIPTION
When ROS is built with Python3, but `python` still executes python2, GatherDeps.cmake will run `generate_cmake_dependency_file.py` with python2, which results in an error, as some ROS modules are not available. If one sets PYTHON_VERSION=3, the proposed fix will run python3 instead of python2. If one does not set this variable, nothing changes and `python` (=`python2`) will be used. I don't know if this is the best way to fix this, please let me know if I should fix it differently.