### PR TITLE
FindGeographicLib: Fix for GeographicLib 2.* and Windows

### DIFF
--- a/cmake/Modules/FindGeographicLib.cmake
+++ b/cmake/Modules/FindGeographicLib.cmake
@@ -10,7 +10,7 @@ find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h PATH_SUFFIXES GeographicLib)
 set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
 
-find_library(GeographicLib_LIBRARIES NAMES Geographic)
+find_library(GeographicLib_LIBRARIES NAMES Geographic GeographicLib GeographicLib-i)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GeographicLib DEFAULT_MSG GeographicLib_LIBRARIES GeographicLib_INCLUDE_DIRS)


### PR DESCRIPTION
Since GeographicLib version 2, the library name changed from `libGeographic.so` to `libGeographicLib.so`, see https://github.com/geographiclib/geographiclib/blob/5e4425da84a46eb70e59656d71b4c99732a570ec/NEWS#L208 .

To ensure that GeographicLib 2.* is found correcty, I think we should add also `GeographicLib` to the names used by `find_library`.

Furthermore, on Windows the import library is called `GeographicLib-i.lib` (see https://github.com/geographiclib/geographiclib/blob/v2.3/src/CMakeLists.txt#L119), so to find the library correctly on Windows we also look for GeographicLib-i .